### PR TITLE
feat: use "doc-include-str" feature flag for lib doc

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,9 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.54.0 # MSRV
+          - '1.46.0' # MSRV
           - stable
           - nightly
+        include:
+          # Disable default "doc-include-str" feature for older Rust.
+          - rust: '1.46.0'
+            cargo-flags: '--no-default-features'
     steps:
       -
         uses: actions/checkout@v2
@@ -38,9 +42,10 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets
+          args: ${{ matrix.cargo-flags }} --all-targets
       -
         name: cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: ${{ matrix.cargo-flags }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,11 @@ description = "Environment variable access helpers"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["doc-include-str"]
+
+# Use "#[doc = include_str!()]" for lib doc (requires Rust 1.54)
+doc-include-str = []
+
 [dependencies]
 thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
-#![doc = include_str!("../README.md")]
+// Conditionally use include_str, for Rust < 1.54.
+// See: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(feature = "doc", feature(extended_key_value_attributes))]
+#![cfg_attr(feature = "doc", cfg_attr(feature = "doc", doc = include_str!("../README.md")))]
 
 pub mod env_vars;


### PR DESCRIPTION
This allows support for older Rust: MSRV 1.54 → 1.46